### PR TITLE
Basic content for launch

### DIFF
--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -29,11 +29,5 @@ second-column:
 third-column:
     title: Useful Links
     items:
-      - name: OpenAMP @ MCA
-        url: http://www.multicore-association.org/workgroup/oamp.php
-      - name: OpenAMP @ GitHub
-        url: https://github.com/OpenAMP/open-amp
-      - name: OpenAMP @ Xilinx
-        url: http://www.wiki.xilinx.com/OpenAMP
-      - name: OpenAMP @ Mentor
-        url: http://www.mentor.com/embedded-multicore-openamp
+      - name: OpenAMP TSC call meeting notes
+        url: https://github.com/OpenAMP/open-amp/wiki#Meeting_Notes

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -9,6 +9,8 @@ brand:
     #   path: /assets/images/ml-platform-logo.png
     url: /
 pages:
+    - title: About
+      url: /about/
     - title: View on GitHub
       url: https://github.com/OpenAMP
       external: true

--- a/_pages/about/README.md
+++ b/_pages/about/README.md
@@ -1,0 +1,20 @@
+---
+layout: flow
+title: About
+permalink: /about/
+---
+# Members
+
+**In alphabetical order**
+
+* Kalray
+* Linaro
+* Mentor
+* Wind River
+* Xilinx
+
+# Membership and Participation
+
+It is not a requirement to be employed at a Member company to participate as a developer or in the OpenAMP Technical Steering Committee.  Community participation is welcome!
+
+Governance of the community project is overseen by a board of representatives from Member companies.  Member fees support administration for the project, such as the project website and mailing lists.

--- a/index.md
+++ b/index.md
@@ -2,7 +2,7 @@
 layout: flow
 title: OpenAMPProject
 description: >-
-    Open Asymmetric Multi-Processing (OpenAMP) is a framework providing the software components needed to enable the development of software applications for asymmetric multi-processing (AMP) systems.
+    OpenAMP (Open Asymmetric Multi-Processing) seeks to standardize the interactions between operating environments in a heterogeneous embedded system through open source solutions for Asymmetric MultiProcessing (AMP).
 jumbotron:
     title: Welcome to OpenAMP
     background-image: /assets/images/content/header-bg.jpg
@@ -13,48 +13,6 @@ jumbotron:
           icon: fa fa-github
 ---
 
-Open Asymmetric Multi-Processing (OpenAMP) is a framework providing the software components needed to enable the development of software applications for asymmetric multi-processing (AMP) systems. It allows operating systems to interact within a broad range of complex homogeneous and heterogeneous architectures and allows asymmetric multiprocessing applications to leverage parallelism offered by the multicore configuration. The framework provides the following key capabilities.
+SoCs (System on a Chip) are becoming more heterogeneous, with multiple processor clusters and special-purpose accelerators. As a result, AMP (Asymmetric MultiProcessing) systems need to be able to run different operating environments side-by-side on the same chip. Developing a standard shared memory scheme for the configuration and interaction between these environments will simplify working with SoCs.
 
-Provides Life Cycle Management, and Inter Processor Communication capabilities for management of remote compute resources and their associated software contexts.
-Provides a standalone library usable with RTOS and baremetal software environments.
-Compatibility with upstream Linux remoteproc, rpmsg and VirtIO components.
-Follow the links in the navigation bar on the left side to find more information.
-
-## OpenAMP releases
-
-###  [](http://openamp.github.io/#201604)2016.04
-
-- Kickoff Meeting Notes:
-- [Meeting Agenda Slides](http://openamp.github.io/docs/2016.04/OpenAMP_kickoff.pdf)
-- [Repo administration discussion](http://openamp.github.io/docs/2016.04/CONTRIBUTING.md)
-- [NXP Modification Overview](http://openamp.github.io/docs/2016.04/NXP_OpenAMP_modifications_overview.pdf)
-- [NXP RPMSG RTOS Overview](http://openamp.github.io/docs/2016.04/rpmsg_rtos_layer_user_guide.pdf)
-
-- Status: Released
-- [OpenAMP 2016.04](https://github.com/OpenAMP/open-amp/releases/tag/v2016.04)
-- [OpenAMP 2016.10](https://github.com/OpenAMP/open-amp/releases/tag/v2016.10)
-- [OpenAMP 2017.04](https://github.com/OpenAMP/open-amp/releases/tag/v2017.04)
-- [libmetal 2016.04](https://github.com/OpenAMP/libmetal/releases/tag/v2016.04)
-- [libmetal 2016.10](https://github.com/OpenAMP/libmetal/releases/tag/v2016.10)
-- [libmetal 2017.04](https://github.com/OpenAMP/libmetal/releases/tag/v2017.04)
-
-###  [](http://openamp.github.io/#201610)2016.10
-
-####  [](http://openamp.github.io/#meeting-notes)Meeting Notes:
-
-- Kickoff Meeting Notes - 2016-05-06:
-- [Meeting Agenda Slides](http://openamp.github.io/docs/2016.10/OpenAMP-2016.10-kickoff.pdf)
-- [Meeting Notes](http://openamp.github.io/docs/2016.10/openamp-2016.10-meeting-notes-2016-05-06.txt)
-
-####  [](http://openamp.github.io/#design-documents)Design Documents
-
-- [NXP RTOS and Sysfs RPMsg Kernel Driver
-Proposal](http://openamp.github.io/docs/2016.10/NXP_OpenAMP_2016_10_Feature_proposal.pdf)
-- libmetal in OpenAMP Discussion - 2016-05-19:
-- [libmetal in OpenAMP](http://openamp.github.io/docs/2016.10/libmetal-in-OpenAMP.pdf)
-- [libmetal in OpenAMP discussion notes](http://openamp.github.io/docs/2016.10/libmetal-in-OpenAMP-MCA-discussion.txt)
-
-- [OpenAMP Large Buffer Proposal](http://openamp.github.io/docs/2016.10/OpenAMP-lbs-proposal.txt)
-- [OpenAMP in Linux Userspace](http://openamp.github.io/docs/2016.10/OpenAMP-Linux-Userspace-With-Libmetal.pdf)
-- [RPMSG Protocol Standardization
-Kickoff](http://openamp.github.io/docs/2016.10/NXP_RPMSG_protocol_standardization_kick_off.pdf)
+OpenAMP (Open Asymmetric Multi-Processing) is a framework providing the software components needed to enable the development of software applications for AMP systems. It allows operating systems to interact within a broad range of complex homogeneous and heterogeneous architectures and allows asymmetric multiprocessing applications to leverage parallelism offered by the multicore configuration.


### PR DESCRIPTION
For re-launch as a Linaro Community Project, I removed a lot of the old OpenAMP content.

In About, I listed the members who have signed on so far.  Will add others as they sign on.

Board/TSC can decide later what other content they want to add.  Keeping it to the minimum for now.

I tried the check-links.sh and every link failed, but I manually clicked some of the links and that seems to work.