### PR TITLE
Updated the build script to ensure that a custom JEKYLL_PORT can be specified

### DIFF
--- a/build-site.sh
+++ b/build-site.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
 
 if [ -z "$JEKYLLSITEBUILD" ]; then
-  export JEKYLLSITEBUILD=latest
+  JEKYLLSITEBUILD=latest
 fi
 if [ -z "$JEKYLL_ENV" ]; then
   export JEKYLL_ENV=staging
 fi
+if [ -z "$JEKYLL_PORT" ]; then
+  JEKYLL_PORT=4000
+fi
 if [ "$JEKYLL_ACTION" = "serve" ]; then
-  PORTS="-p 4000:4000"
+  PORTS="-p $JEKYLL_PORT:4000"
 else
   PORTS=""
 fi


### PR DESCRIPTION
- Adding ability to specify a custom JEKYLL_PORT (this is an update being applied to all the Linaro maintained static websites to allow end-users to build multiple sites simultaneously by specifying a different port to serve the site on.